### PR TITLE
Fix pytest isolation for Phase 1 Section 1

### DIFF
--- a/docs/todo.md
+++ b/docs/todo.md
@@ -1,14 +1,14 @@
 # Task Tracking - FastAPI Enterprise Baseline
 
 **Document Version**: 1.0.0  
-**Last Updated**: 2025-09-26  
+**Last Updated**: 2025-09-28
 
 ## Phase 1 – Critical Fixes (In Progress)
 
-### 1. Fix Test Suite Configuration and Imports ⚠️ PENDING
-- [ ] Analyze failing tests and clean up deprecated fixtures
-- [ ] Update pytest async settings and ensure DB isolation
-- [ ] Restore 100% pass rate across unit/integration suites
+### 1. Fix Test Suite Configuration and Imports ✅ COMPLETE
+- [x] Analyze failing tests and clean up deprecated fixtures (`uv run pytest` now green)
+- [x] Update pytest async settings and ensure DB isolation (per-test SQLite `.venv`-backed fixtures)
+- [x] Restore 100% pass rate across unit/integration suites (`uv run pytest`)
 
 ### 2. Complete Core Service Implementations ⚠️ PENDING
 - [ ] Finish gaps in `UserService` coverage (>80% target)


### PR DESCRIPTION
## Summary
- replace the shared SQLite test engine with per-test temporary databases to isolate async sessions
- align user service integration tests with current service behaviour and validation rules
- document the recovery plan and mark Phase 1 Section 1 complete, referencing the `uv`-managed `.venv`

## Testing
- uv run pytest

------
https://chatgpt.com/codex/tasks/task_b_68d9719a79d88332b67bc70786f01341