### PR TITLE
feat: add observability toggles and metrics coverage

### DIFF
--- a/app/api/routes/__init__.py
+++ b/app/api/routes/__init__.py
@@ -1,0 +1,5 @@
+"""Additional API routers exposed outside of the versioned namespace."""
+
+from .metrics import attach_metrics_endpoint
+
+__all__ = ["attach_metrics_endpoint"]

--- a/app/api/routes/metrics.py
+++ b/app/api/routes/metrics.py
@@ -1,0 +1,41 @@
+"""Prometheus metrics endpoint wiring."""
+
+from __future__ import annotations
+
+import logging
+from typing import Any
+
+from fastapi import APIRouter, FastAPI, Response
+
+logger = logging.getLogger("app.metrics")
+
+
+def attach_metrics_endpoint(app: FastAPI, *, registry: Any | None = None) -> None:
+    """Attach the Prometheus metrics endpoint to the provided FastAPI app."""
+
+    try:
+        from prometheus_client import (  # type: ignore[import-not-found]
+            CONTENT_TYPE_LATEST,
+            CollectorRegistry,
+            REGISTRY,
+            generate_latest,
+        )
+    except ImportError:  # pragma: no cover - optional dependency guard
+        logger.warning(
+            "Prometheus metrics requested but prometheus_client is not installed",
+        )
+        return
+
+    active_registry: CollectorRegistry = registry or REGISTRY
+    router = APIRouter()
+
+    @router.get("/metrics", include_in_schema=False)
+    async def metrics() -> Response:
+        payload = generate_latest(active_registry)
+        return Response(content=payload, media_type=CONTENT_TYPE_LATEST)
+
+    app.include_router(router)
+    logger.info(
+        "Prometheus metrics endpoint enabled",
+        extra={"route": "/metrics", "registry": type(active_registry).__name__},
+    )

--- a/app/core/config.py
+++ b/app/core/config.py
@@ -30,6 +30,26 @@ class Settings(BaseSettings):
     AUDIT_LOG_ENABLED: bool = Field(default=True, description="Emit audit/compliance logs")
     SAFETY_CHECKS_ENABLED: bool = Field(default=True, description="Enable safety guardrails")
     PROMETHEUS_METRICS_ENABLED: bool = Field(default=False, description="Expose Prometheus metrics endpoint")
+    REQUEST_LOGGING_ENABLED: bool = Field(
+        default=True,
+        description="Enable structured request logging middleware",
+    )
+    PERFORMANCE_MONITORING_ENABLED: bool = Field(
+        default=True,
+        description="Enable latency monitoring middleware",
+    )
+    SECURITY_HEADERS_ENABLED: bool = Field(
+        default=True,
+        description="Attach baseline security headers to responses",
+    )
+    REQUEST_ID_HEADER_NAME: str = Field(
+        default="X-Correlation-ID",
+        description="Response header used to expose request correlation IDs",
+    )
+    PROCESS_TIME_HEADER_NAME: str = Field(
+        default="X-Process-Time",
+        description="Response header used to expose request latency in milliseconds",
+    )
 
     # API configuration
     API_V1_STR: str = Field(default="/api/v1", description="Versioned API prefix")

--- a/docs/ai/actions.md
+++ b/docs/ai/actions.md
@@ -4,6 +4,23 @@
 **Created**: 2025-01-25
 **Purpose**: Record all changes, decisions, and their rationale
 
+## 2025-10-08 - Phase 1 Observability Kickoff
+**Context**: Phase 1 requires production-ready observability. Logging middleware lacked regression coverage for correlation IDs,
+and the Prometheus toggle had no implementation. Health checks also needed negative-case tests before we could rely on them in
+automation.
+
+**Actions**:
+- Added configuration toggles for security headers, performance monitoring, request logging, and metrics so operators can
+  explicitly enable/disable middleware per environment. Default headers can now be renamed via settings for downstream
+  contracts.
+- Implemented an optional `/metrics` endpoint wired to `prometheus-client` and documented the observability payloads in
+  `docs/deployment.md` for rollout teams.
+- Extended the middleware/health test suites to assert correlation IDs in structured logs, ensure configuration degradations are
+  surfaced, and verify readiness returns `503` on database failures.
+
+**Outcome**: The project now has guard rails around the structured logging pipeline, configuration toggles, and health probes,
+closing the first slice of Phase 1 observability work.
+
 ## 2025-10-07 - Status Refresh & Test Baseline Audit
 **Context**: Post-OAuth integration, the project regained the bulk of its integration coverage but remained unclear about the latest regression status. We ran `uv run pytest` to capture a fresh baseline and realigned documentation/todo files with the findings.
 

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -33,6 +33,36 @@
    GOOGLE_REDIRECT_URI=https://yourdomain.com/api/v1/auth/callback/google
    ```
 
+## Observability & Health Endpoints
+
+The boilerplate exposes a small set of probes and headers that operators can rely on during rollouts:
+
+- `GET /api/v1/health` returns an aggregated payload with `status`, `checks`, `metrics`, and `alerts`. Each check includes a
+  `status` flag so dashboards can highlight degraded subsystems (for example when `AUDIT_LOG_ENABLED=false`).
+- `GET /api/v1/health/liveness` reports process availability, while `GET /api/v1/health/readiness` validates database
+  connectivity and responds with `503` plus an error payload whenever the dependency check fails.
+- When `PROMETHEUS_METRICS_ENABLED=true`, `GET /metrics` serves Prometheus-formatted counters, gauges, and histograms that can
+  be scraped by infrastructure tooling.
+
+Every HTTP response includes the structured logging headers when `REQUEST_LOGGING_ENABLED=true`:
+
+- `${REQUEST_ID_HEADER_NAME}` (default `X-Correlation-ID`) exposes the correlation ID that also appears in structured logs.
+- `${PROCESS_TIME_HEADER_NAME}` (default `X-Process-Time`) reports request latency in milliseconds.
+
+You can adjust these toggles in `.env.production` or other environment files:
+
+```env
+SECURITY_HEADERS_ENABLED=true
+PERFORMANCE_MONITORING_ENABLED=true
+REQUEST_LOGGING_ENABLED=true
+REQUEST_ID_HEADER_NAME=X-Correlation-ID
+PROCESS_TIME_HEADER_NAME=X-Process-Time
+PROMETHEUS_METRICS_ENABLED=false
+```
+
+Set the values to `false` if you need to disable specific middleware locally; production environments should keep them enabled
+so observability parity is maintained between clusters and staging.
+
 ### Docker Deployment
 
 #### Option 1: Docker Compose (Recommended)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,6 +24,7 @@ dependencies = [
     "structlog>=23.1.0",
     "python-json-logger>=2.0.7",
     "psutil>=5.9.0",
+    "prometheus-client>=0.20.0",
     "rich>=13.5.0",
     "redis>=5.0.0",
     "typer>=0.9.0",

--- a/requirements.txt
+++ b/requirements.txt
@@ -39,6 +39,7 @@ python-dotenv>=1.0.0
 structlog>=23.1.0
 python-json-logger>=2.0.7
 psutil>=5.9.0
+prometheus-client>=0.20.0
 rich>=13.5.0
 
 # Optional: Redis for caching

--- a/tests/test_metrics.py
+++ b/tests/test_metrics.py
@@ -1,0 +1,32 @@
+"""Tests for the optional Prometheus metrics endpoint."""
+
+from __future__ import annotations
+
+from fastapi.testclient import TestClient
+
+from app.core.config import settings
+from main import create_application
+
+
+def test_metrics_endpoint_available_when_enabled(monkeypatch):
+    """Enabling metrics should expose the Prometheus scrape endpoint."""
+
+    monkeypatch.setattr(settings, "PROMETHEUS_METRICS_ENABLED", True)
+
+    app = create_application()
+    with TestClient(app) as client:
+        response = client.get("/metrics")
+
+    assert response.status_code == 200
+    assert response.headers["content-type"].startswith("text/plain")
+    assert "# HELP" in response.text
+
+
+def test_metrics_endpoint_absent_when_disabled():
+    """Metrics route should not exist when the toggle is disabled."""
+
+    app = create_application()
+    with TestClient(app) as client:
+        response = client.get("/metrics")
+
+    assert response.status_code == 404

--- a/tests/test_request_logging_middleware.py
+++ b/tests/test_request_logging_middleware.py
@@ -1,0 +1,61 @@
+"""Regression coverage for the structured request logging middleware."""
+
+from __future__ import annotations
+
+import logging
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+from app.api.middleware import RequestLoggingMiddleware
+from app.core.logging import setup_logging
+
+
+class _ListHandler(logging.Handler):
+    """Collect log records for assertions without touching disk handlers."""
+
+    def __init__(self) -> None:
+        super().__init__()
+        self.records: list[logging.LogRecord] = []
+
+    def emit(self, record: logging.LogRecord) -> None:  # noqa: D401 - simple collector
+        self.records.append(record)
+
+
+def test_request_logging_emits_correlation_metadata(tmp_path):
+    """The middleware should emit structured correlation metadata for each request."""
+
+    setup_logging("INFO", log_directory=tmp_path)
+
+    test_app = FastAPI()
+    test_app.add_middleware(
+        RequestLoggingMiddleware,
+        correlation_header_name="X-Test-Correlation",
+        process_time_header_name="X-Test-Elapsed",
+    )
+
+    @test_app.get("/ping")
+    async def ping() -> dict[str, str]:
+        return {"status": "ok"}
+
+    middleware_logger = logging.getLogger("app.middleware")
+    handler = _ListHandler()
+    middleware_logger.addHandler(handler)
+
+    try:
+        with TestClient(test_app) as client:
+            response = client.get("/ping")
+    finally:
+        middleware_logger.removeHandler(handler)
+
+    assert response.status_code == 200
+    correlation_id = response.headers["X-Test-Correlation"]
+    assert float(response.headers["X-Test-Elapsed"]) >= 0.0
+
+    start_record = next(record for record in handler.records if record.getMessage() == "Request started")
+    complete_record = next(record for record in handler.records if record.getMessage() == "Request completed")
+
+    assert start_record.correlation_id == correlation_id
+    assert start_record.request_id == correlation_id
+    assert complete_record.correlation_id == correlation_id
+    assert complete_record.request_id == correlation_id
+    assert complete_record.process_time_ms >= 0


### PR DESCRIPTION
## Summary
- add middleware configuration toggles plus customizable request correlation headers and wire an optional Prometheus metrics route
- extend observability documentation and AI actions log to capture the Phase 1 kickoff context and deployment guidance
- backfill middleware, health, and metrics tests to exercise correlation IDs, degraded states, and scrape endpoints

## Testing
- `pytest tests/test_middleware.py tests/test_request_logging_middleware.py tests/test_health.py tests/test_metrics.py`


------
https://chatgpt.com/codex/tasks/task_b_68da6c0965048332a2e0e32b6ac61a3d