### PR TITLE
docs: refresh backlog after latest test run

### DIFF
--- a/docs/ai/actions.md
+++ b/docs/ai/actions.md
@@ -1,8 +1,27 @@
 # Actions Log - FastAPI Enterprise Baseline
 
-**Document Version**: 1.2.0
+**Document Version**: 1.3.0
 **Created**: 2025-01-25
 **Purpose**: Record all changes, decisions, and their rationale
+
+## 2025-10-09 - Test Baseline Audit & Documentation Realignment
+
+**Context**: Ran the full suite to validate our baseline before planning the next phase of work. The run surfaced eight additional tests (210 total), a modest coverage uptick, and a handful of new deprecation/SQLAlchemy warnings that were not reflected in the living docs.
+
+**Actions**:
+- Executed `uv run pytest` to confirm a green build, capture updated coverage (75%), and enumerate new warnings for triage.
+- Updated `docs/todo.md` status snapshot and tooling backlog with the latest test counts, coverage percentage, and warning remediation task.
+- Refreshed `docs/ai/improvement-plan.md` to reflect the new metrics, incorporate warning remediation into Phase 1, and clarify immediate next steps.
+
+**Impact**:
+- Documentation now mirrors the repository's actual state, preventing drift before we stand up CI automation.
+- Warning remediation is tracked explicitly so the team can prioritise fixes alongside the coverage push.
+- The living plan highlights that CI remains outstanding despite local success, keeping stakeholders aligned on risk.
+
+**Next Steps**:
+- Prioritise coverage improvements across `auth.py`, `database.py`, and CLI paths to close the remaining gap to 80%.
+- Tackle the new warning set (pythonjsonlogger import path, deprecated `crypt`, Starlette 422 constant, SQLAlchemy flush usage).
+- Draft CI automation work to lock the green baseline into GitHub Actions.
 
 ## 2025-10-04 - Developer Experience Smoke Checks & CI Guide
 

--- a/docs/ai/improvement-plan.md
+++ b/docs/ai/improvement-plan.md
@@ -1,7 +1,7 @@
 # FastAPI Enterprise Baseline - Improvement Plan
 
-**Document Version**: 1.3.0
-**Last Updated**: 2025-10-04
+**Document Version**: 1.4.0
+**Last Updated**: 2025-10-09
 **Status**: Active Development
 
 ## Executive Summary
@@ -17,8 +17,9 @@ This plan guides the ongoing evolution of the FastAPI enterprise baseline. The c
 - Modern Python 3.12 target, Ruff-first tooling, and uv-backed workflows already standardised.
 
 **Current Gaps** ⚠️
-- `pytest` now runs clean locally (**202 passed**) after pinning bcrypt to the supported range, but CI automation is still missing.
-- Coverage sits at **74%** (goal ≥80%); low-coverage zones include `app/api/v1/endpoints/auth.py`, `app/core/database.py`, OAuth providers, and the CLI helpers.
+- `pytest` now runs clean locally (**210 passed**) but CI automation is still missing and should guard against regressions.
+- Coverage sits at **75%** (goal ≥80%); low-coverage zones include `app/api/v1/endpoints/auth.py`, `app/core/database.py`, OAuth providers, and the CLI helpers.
+- Runtime warnings surfaced during the latest run (`pythonjsonlogger` import path, deprecated `crypt`, Starlette 422 constant, SQLAlchemy flush warning) and require remediation alongside the coverage push.
 - RBAC regression coverage should broaden to high-sensitivity admin endpoints now that dependency guard behaviour is locked in.
 
 ## Implementation Roadmap
@@ -30,6 +31,7 @@ This plan guides the ongoing evolution of the FastAPI enterprise baseline. The c
 - [ ] Backfill integration tests around `/api/v1/auth/login`, `/api/v1/auth/token`, and OAuth provider error paths to lift coverage in `auth.py`, `database.py`, and `app/services/oauth/`.
 - [ ] Expand RBAC test coverage for admin-only endpoints and document the smoke scenarios alongside seeded defaults.
 - [ ] Stand up CI with lint + test automation so regressions surface automatically.
+- [ ] Address new warnings by migrating to `pythonjsonlogger.json`, replacing Python `crypt`, updating Starlette 422 usage, and adjusting SQLAlchemy flush patterns when needed.
 - [x] Replace deprecated `datetime.utcnow()` usage with timezone-aware alternatives and modern Pydantic serializers.
 - [x] Document structured logging rollout and health-check payloads in README/deployment guides.
 
@@ -105,7 +107,7 @@ This plan guides the ongoing evolution of the FastAPI enterprise baseline. The c
 ### Immediate Actions (Next 1-2 Days)
 1. Raise auth/DB coverage by exercising refresh, error, and provider edge cases.
 2. Outline RBAC regression scenarios for admin endpoints and backfill docs detailing default role/permission seeding.
-3. Capture bcrypt pin + dependency corrections in onboarding/setup docs (completed here).
+3. Remediate the new warning set (pythonjsonlogger import, deprecated `crypt`, Starlette 422 constant, SQLAlchemy flush behaviour) or document workarounds until fixes land.
 
 ### Near-Term (This Sprint)
 1. Push coverage above 80% by focusing on the uncovered modules.

--- a/docs/todo.md
+++ b/docs/todo.md
@@ -1,12 +1,12 @@
 # Task Tracking - FastAPI Enterprise Baseline
 
-**Document Version**: 2.3.0
-**Last Updated**: 2025-10-04
+**Document Version**: 2.4.0
+**Last Updated**: 2025-10-09
 
-> **Status Snapshot (2025-10-04)**
-> - `pytest` → **202 passed / 0 failed / 202 total**.
-> - Coverage: **74%** — biggest gaps remain in `app/api/v1/endpoints/auth.py`, `app/core/database.py`, and CLI utilities.
-> - Runtime warnings addressed; remaining TODOs focus on coverage, CI automation, and developer documentation refreshes.
+> **Status Snapshot (2025-10-09)**
+> - `pytest` → **210 passed / 0 failed / 210 total** (coverage report generated via `uv run pytest`).
+> - Coverage: **75%** — biggest gaps remain in `app/api/v1/endpoints/auth.py`, `app/core/database.py`, and CLI utilities (`app/cli.py`).
+> - Deprecation warnings surfaced (`pythonjsonlogger`, `crypt`, Starlette 422 constant) alongside an SAWarning during repository flushes — track remediation alongside coverage and CI work.
 
 The following backlog keeps the boilerplate modular, production-ready, and easy for new teams to adopt. Each section calls out the concrete steps required for completion.
 
@@ -36,6 +36,7 @@ The following backlog keeps the boilerplate modular, production-ready, and easy 
 - [ ] Enforce linting/formatting in CI: wire `uv run ruff check` and `ruff format --check`, update pre-commit hooks, and document workflow (CI workflow in progress).
 - [ ] Replace brittle mocks with shared pytest fixtures/factories for services, repositories, and OAuth providers to improve readability and reuse.
 - [x] Resolve pytest warning noise (Pydantic serializers, `datetime.utcnow()`) to keep future upgrades low-risk.
+- [ ] Eliminate remaining warnings by migrating to `pythonjsonlogger.json`, replacing Python `crypt` usage, and updating Starlette 422 constant references; investigate SQLAlchemy `Session.add` warning seen during flush events.
 
 ## 5. Documentation & Developer Experience (In Progress)
 - [x] Update docs (`README`, `docs/ai/*`, `docs/features/`) to reflect the unified repository/service patterns and observability stack.


### PR DESCRIPTION
## Summary
- update docs/todo.md with the latest pytest counts, coverage metrics, and warning remediation tasks
- refresh the improvement plan to call out the new warning set and updated coverage numbers
- log the baseline audit in docs/ai/actions.md so knowledge sharing stays current

## Testing
- uv run pytest

------
https://chatgpt.com/codex/tasks/task_b_68e1bc52dc18833284020aa72b4f25de