### PR TITLE
Fix user update uniqueness validation

### DIFF
--- a/app/services/user.py
+++ b/app/services/user.py
@@ -268,7 +268,7 @@ class UserService:
         # Validate username uniqueness, defaulting to the current username so
         # callers updating only email still trigger the guard.
         username_candidate = update_dict.get("username", user.username)
-        if username_candidate:
+        if username_candidate is not None:
             username_conflict = await self.repository.exists(
                 field_name="username",
                 field_value=username_candidate,

--- a/app/services/user.py
+++ b/app/services/user.py
@@ -253,23 +253,29 @@ class UserService:
 
         update_dict = user_data.model_dump(exclude_unset=True, exclude={"role_names"})
 
-        # Validate email uniqueness if being updated
-        if "email" in update_dict and await self.repository.exists(
-            field_name="email",
-            field_value=update_dict["email"],
-            exclude_id=user_id,
-        ):
-            raise ConflictError(f"Email {update_dict['email']} is already in use")
-
-        # Validate username uniqueness if being updated
-        if "username" in update_dict and await self.repository.exists(
-            field_name="username",
-            field_value=update_dict["username"],
-            exclude_id=user_id,
-        ):
-            raise ConflictError(
-                f"Username {update_dict['username']} is already taken"
+        # Validate email uniqueness regardless of whether it changed to ensure
+        # both identifiers remain globally unique.
+        email_candidate = update_dict.get("email", user.email)
+        if email_candidate is not None:
+            email_conflict = await self.repository.exists(
+                field_name="email",
+                field_value=email_candidate,
+                exclude_id=user_id,
             )
+            if email_conflict:
+                raise ConflictError(f"Email {email_candidate} is already in use")
+
+        # Validate username uniqueness, defaulting to the current username so
+        # callers updating only email still trigger the guard.
+        username_candidate = update_dict.get("username", user.username)
+        if username_candidate:
+            username_conflict = await self.repository.exists(
+                field_name="username",
+                field_value=username_candidate,
+                exclude_id=user_id,
+            )
+            if username_conflict:
+                raise ConflictError(f"Username {username_candidate} is already taken")
 
         try:
             updated_user = await self.repository.update(user, update_dict)

--- a/docs/ai/actions.md
+++ b/docs/ai/actions.md
@@ -28,7 +28,7 @@ pattern.
 
 **Next Steps**:
 - Triage the remaining warning backlog (deprecated crypt usage, Starlette 422 constant, SQLAlchemy flush advisory).
-- Consider enforcing composite uniqueness at the database level for additional defence-in-depth.
+- Consider enforcing individual unique constraints on both the email and username columns at the database level for additional defence-in-depth.
 - Expand coverage around the auth and database modules to push toward the 80% target.
 
 ## 2025-10-07 - Regression Audit & Documentation Realignment

--- a/docs/ai/spec.md
+++ b/docs/ai/spec.md
@@ -171,10 +171,11 @@ class User:
 - `get_users_paginated(skip: int, limit: int) -> List[User]`
 
 #### Validation Rules
-- Email must be unique and valid format
-- Username must be unique (if provided)
-- Password minimum 8 characters
-- Password must contain letter and number
+- Email must remain unique across all users and is validated on both create and update flows.
+- Username must remain unique across all users (including updates) and defaults to lowercase enforcement.
+- Update operations run independent uniqueness checks for email and username so email-only changes still validate both fields.
+- Conflicts surface as `ConflictError` (HTTP 409) responses with descriptive detail messages for API clients.
+- Passwords require a minimum of 8 characters and must contain at least one letter and one number.
 
 ### 4.2 AuthService
 


### PR DESCRIPTION
## Summary
- ensure `UserService.update_user` checks both email and username uniqueness, even on email-only updates
- document the regression fix in `docs/ai/actions.md` and note the dual checks in the service specification

## Testing
- uv run pytest
- uv run ruff check .

------
https://chatgpt.com/codex/tasks/task_b_68e52b7e9c0883328ee2ca2bf85a087d