### PR TITLE
finishing off stablizing work

### DIFF
--- a/app/api/errors.py
+++ b/app/api/errors.py
@@ -22,7 +22,7 @@ from app.services.base import (
 
 logger = logging.getLogger(__name__)
 
-HTTP_422_STATUS = getattr(status, "HTTP_422_UNPROCESSABLE_CONTENT", 422)
+HTTP_422_STATUS = status.HTTP_422_UNPROCESSABLE_CONTENT
 
 
 def _request_id_from(request: Request) -> str | None:

--- a/app/api/v1/endpoints/users.py
+++ b/app/api/v1/endpoints/users.py
@@ -18,7 +18,7 @@ from app.services.user import UserService
 
 router = APIRouter()
 
-HTTP_422_STATUS = getattr(status, "HTTP_422_UNPROCESSABLE_CONTENT", 422)
+HTTP_422_STATUS = status.HTTP_422_UNPROCESSABLE_CONTENT
 
 
 @router.get("/me", response_model=UserResponse)

--- a/docs/ai/actions.md
+++ b/docs/ai/actions.md
@@ -4,6 +4,24 @@
 **Created**: 2025-01-25
 **Purpose**: Record all changes, decisions, and their rationale
 
+## 2025-10-11 - Warning Remediation
+
+**Context**: Pytest surfaced warnings for deprecated stdlib `crypt` helpers, Starlette's legacy 422 constant, and an SQLAlchemy advisory about calling `Session.add()` during concurrent flushes.
+
+**Actions**:
+- Audited password hashing to ensure every code path uses the existing bcrypt helpers and removed the legacy stdlib `crypt` access that triggered deprecation noise.
+- Standardised every HTTP 422 response on `status.HTTP_422_UNPROCESSABLE_CONTENT`, eliminating fallback constants that Starlette deprecated.
+- Added an async write lock to the base repository so create/update/delete operations cannot interleave while a flush runs, clearing the SQLAlchemy warning observed in concurrency tests.
+- Confirmed `uv run pytest` now completes without the previous warning trio (only the known asyncio event-loop warning remains).
+
+**Impact**:
+- Test and CI logs are clean of deprecated `crypt`/Starlette/SQLAlchemy messages, reducing noise for contributors.
+- Repository writes are deterministic under concurrent load, avoiding undefined SQLAlchemy behaviour.
+- The backlog warning item is complete, unblocking the coverage uplift work.
+
+**Next Steps**:
+- Focus on the coverage uplift for auth, database, and OAuth flows outlined in the backlog.
+
 ## 2025-10-11 - CI Automation Enablement
 
 **Context**: With the regression resolved and the suite green, we needed to prevent future slips by automating the uv-based quality gates.

--- a/docs/todo.md
+++ b/docs/todo.md
@@ -6,7 +6,7 @@
 > **Status Snapshot (2025-10-11)**
 > - `uv run pytest` → **211 passed / 0 failed / 211 total**; CI automation (`.github/workflows/ci.yml`) now enforces the green baseline on pushes and PRs targeting `main`.
 > - Coverage: **75%** (goal ≥80%) — biggest gaps remain in `app/api/v1/endpoints/auth.py`, `app/core/database.py`, CLI helpers (`app/cli.py`), and OAuth provider flows.
-> - Runtime warnings persist: deprecated `crypt` usage, Starlette 422 constant references, and an SQLAlchemy `Session.add()` SAWarning emitted during flushes. The `pythonjsonlogger` import warning has been resolved, but the remaining items stay open until code changes land.
+> - Runtime warnings have been cleared: bcrypt now backs all password helpers, 422 responses rely on `HTTP_422_UNPROCESSABLE_CONTENT`, and repository writes guard concurrent `Session.add()` usage. Only the known asyncio test ResourceWarning remains.
 
 The following backlog keeps the boilerplate modular, production-ready, and easy for new teams to adopt. Each section calls out the concrete steps required for completion.
 
@@ -35,7 +35,7 @@ The following backlog keeps the boilerplate modular, production-ready, and easy 
 - [ ] Resolve the `UserService.update_user` regression: align the uniqueness guard with expectations (double `exists` check or spec adjustment) and restore the unit test to green.
 - [ ] Document the outcome in `docs/ai/spec.md` / lessons and add regression coverage for mixed email/username updates.
 - [x] Restore `uv run pytest` to green and keep it stable via CI automation (GitHub Actions or equivalent) that runs `uv sync`, `uv run ruff check ..`, `uv run ruff format --check ..`, and `uv run pytest` using the uv virtualenv bootstrap.
-- [ ] Replace deprecated Python `crypt` usage, update Starlette 422 constant references, and address the SQLAlchemy `Session.add()` warning surfaced during flush operations.
+- [x] Replace deprecated Python `crypt` usage, update Starlette 422 constant references, and address the SQLAlchemy `Session.add()` warning surfaced during flush operations.
 - [x] Replace brittle mocks with shared pytest fixtures/factories for services, repositories, and OAuth providers to improve readability and reuse.
 - [x] Resolve pytest warning noise (Pydantic serializers, timezone-aware datetimes) to keep future upgrades low-risk.
 - [x] Migrate structured logging to use `pythonjsonlogger.json.JsonFormatter` to remove import deprecation warnings.

--- a/tests/test_errors.py
+++ b/tests/test_errors.py
@@ -11,7 +11,7 @@ from app.services.base import (
     EntityNotFoundError,
 )
 
-HTTP_422_STATUS = getattr(status, "HTTP_422_UNPROCESSABLE_CONTENT", 422)
+HTTP_422_STATUS = status.HTTP_422_UNPROCESSABLE_CONTENT
 
 def _build_app() -> FastAPI:
     app = FastAPI()


### PR DESCRIPTION
This pull request focuses on cleaning up deprecated warnings and improving concurrency safety in the repository layer. The main changes include standardizing the HTTP 422 status constant, introducing an async write lock to prevent concurrent write operations in the base repository, and updating documentation to reflect these improvements and the resolution of previous runtime warnings.

**Warning remediation and concurrency improvements:**

* Standardized all HTTP 422 status references to use `status.HTTP_422_UNPROCESSABLE_CONTENT`, removing deprecated fallback logic in `app/api/errors.py`, `app/api/v1/endpoints/users.py`, and `tests/test_errors.py`. [[1]](diffhunk://#diff-00ea9caa1d55cf7790e37c889c943082a783d12202bafe4361d42319af4b01e9L25-R25) [[2]](diffhunk://#diff-edcf7400f308928d943084e68c5defa3c4ff9fbf0fd4d02451f157082a323bc0L21-R21) [[3]](diffhunk://#diff-6e5030d96839d3fe377cf209b6cab5b0d50ae900b458248d8c24b61774117170L14-R14)
* Added an `asyncio.Lock` (`_write_lock`) to the `BaseRepository` in `app/repositories/base.py` and wrapped `create`, `update`, and `delete` methods with `async with self._write_lock:` to prevent concurrent flushes and resolve SQLAlchemy warnings. [[1]](diffhunk://#diff-237057eb458577690dffe6c5e653effc8b608072503be88f7fea68a457f4d093R5) [[2]](diffhunk://#diff-237057eb458577690dffe6c5e653effc8b608072503be88f7fea68a457f4d093R34) [[3]](diffhunk://#diff-237057eb458577690dffe6c5e653effc8b608072503be88f7fea68a457f4d093R219) [[4]](diffhunk://#diff-237057eb458577690dffe6c5e653effc8b608072503be88f7fea68a457f4d093R252) [[5]](diffhunk://#diff-237057eb458577690dffe6c5e653effc8b608072503be88f7fea68a457f4d093R285)

**Documentation updates:**

* Added a new changelog entry in `docs/ai/actions.md` documenting the warning remediation work, its context, actions, and impact.
* Updated `docs/todo.md` to mark the warning-clearing tasks as complete and reflect the new, cleaner test/CI status. [[1]](diffhunk://#diff-d84697334acf64fe5d67dfd34f6370dca462f602aa3a720711eae12bf8dd153dL9-R9) [[2]](diffhunk://#diff-d84697334acf64fe5d67dfd34f6370dca462f602aa3a720711eae12bf8dd153dL38-R38)