### PR TITLE
test: lift auth and database coverage above 80%

### DIFF
--- a/docs/DOCUMENTATION_UPDATES.md
+++ b/docs/DOCUMENTATION_UPDATES.md
@@ -1,6 +1,7 @@
 # 📋 Documentation and Configuration Updates Summary
 
 ## 2025-10-03 — Dependency & Documentation Alignment
+- Executed `uv run pytest --cov=app` (253 passed, **82% coverage**) after adding dedicated auth/database/OAuth tests, and updated this log plus `docs/ai/improvement-plan.md` with the new baseline.
 - Added missing runtime dependencies (`itsdangerous`, `typer`) and pinned `bcrypt` to `<4` across `requirements.txt` and `pyproject.toml` so the FastAPI app and tests boot without manual intervention.
 - Regenerated the local test baseline (`pytest` → 202 passed, 74% coverage) and captured the results in `docs/todo.md` / `docs/ai/improvement-plan.md`.
 - Updated `README.md` to reflect the actual repository name, rediscovered metrics capabilities, and corrected Docker commands.

--- a/docs/ai/actions.md
+++ b/docs/ai/actions.md
@@ -175,6 +175,7 @@ pattern.
 **Actions**:
 - Added explicit pins for `itsdangerous`, `typer`, and `bcrypt>=3.2,<4.0` in `requirements.txt` / `pyproject.toml` to match the FastAPI stack.
 - Re-ran `pytest` after the dependency fixes, capturing a clean baseline (**202 passed**, 74% coverage) for reference in docs.
+- Follow-up run (`uv run pytest --cov=app`) after targeted auth/database/OAuth tests delivered **253 passed** and **82% coverage**, and the living docs were updated accordingly.
 - Updated `README.md` quick-start paths, feature descriptions, and Docker guidance to reflect the current repository layout.
 - Refreshed `docs/todo.md` and `docs/ai/improvement-plan.md` with accurate status snapshots, outstanding gaps, and immediate priorities.
 - Logged the work here to maintain an audit trail for downstream contributors.

--- a/docs/ai/improvement-plan.md
+++ b/docs/ai/improvement-plan.md
@@ -18,7 +18,7 @@ This plan guides the ongoing evolution of the FastAPI enterprise baseline. The c
 
 **Current Gaps** ⚠️
 - Latest regression run (`uv run pytest`) surfaces one failure (`TestUserService::test_update_user_success`) because the uniqueness guard only checks the email field. CI automation is still missing, so the breakage was caught manually.
-- Coverage sits at **75%** (goal ≥80%); low-coverage zones include `app/api/v1/endpoints/auth.py`, `app/core/database.py`, OAuth providers, and the CLI helpers.
+- Coverage now sits at **82%** (goal ≥80% achieved); remaining low-coverage zones include `app/api/v1/endpoints/health.py`, the CLI helpers, and select database utilities earmarked for follow-up.
 - Runtime warnings persist: deprecated `crypt` usage, Starlette 422 constant references, and an SQLAlchemy `Session.add()` warning emitted during flushes. The `pythonjsonlogger` import warning has been addressed, but the remaining clean-up is pending.
 - RBAC regression coverage should broaden to high-sensitivity admin endpoints now that dependency guard behaviour is locked in.
 

--- a/tests/unit/test_auth_endpoint_errors.py
+++ b/tests/unit/test_auth_endpoint_errors.py
@@ -1,0 +1,439 @@
+"""Additional coverage for error branches in app.api.v1.endpoints.auth."""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+from unittest.mock import AsyncMock
+
+import pytest
+from fastapi import HTTPException
+
+from app.core.exceptions import (
+    AuthenticationError,
+    AuthorizationError,
+    ValidationError as AppValidationError,
+)
+from app.schemas.oauth import AuthorizationRequest, TokenRequest
+
+
+@pytest.mark.asyncio
+async def test_authorize_local_requires_credentials(monkeypatch) -> None:
+    """Local authorization should reject requests without credentials."""
+
+    class DummyAuthService:
+        def __init__(self, *_args, **_kwargs) -> None:  # pragma: no cover - simple stub
+            pass
+
+    monkeypatch.setattr(
+        "app.api.v1.endpoints.auth.AuthService", DummyAuthService
+    )
+
+    from app.api.v1.endpoints.auth import authorize
+
+    request = AuthorizationRequest(
+        provider="local",
+        client_id="client",
+        redirect_uri="https://client.example.com/callback",
+        state="state-123",
+    )
+
+    with pytest.raises(HTTPException) as exc:
+        await authorize(request, AsyncMock())
+
+    assert exc.value.status_code == 400
+    assert "Username and password required" in exc.value.detail
+
+
+@pytest.mark.asyncio
+async def test_authorize_local_authorization_error(monkeypatch) -> None:
+    """Authorization errors should translate to HTTP 403 responses."""
+
+    class DummyAuthService:
+        def __init__(self, *_args, **_kwargs) -> None:
+            pass
+
+        async def authorize_local(self, *_args, **_kwargs):
+            raise AuthorizationError("forbidden")
+
+    monkeypatch.setattr(
+        "app.api.v1.endpoints.auth.AuthService", DummyAuthService
+    )
+
+    from app.api.v1.endpoints.auth import authorize
+
+    request = AuthorizationRequest(
+        provider="local",
+        client_id="client",
+        redirect_uri="https://client.example.com/callback",
+        state="state-123",
+        username="user@example.com",
+        password="secret",
+    )
+
+    with pytest.raises(HTTPException) as exc:
+        await authorize(request, AsyncMock())
+
+    assert exc.value.status_code == 403
+    assert "forbidden" in exc.value.detail
+
+
+@pytest.mark.asyncio
+async def test_authorize_local_app_validation_error(monkeypatch) -> None:
+    """Pydantic-style validation errors should map to HTTP 400."""
+
+    class FailingAuthService:
+        def __init__(self, *_args, **_kwargs) -> None:
+            raise AppValidationError("invalid payload")
+
+    monkeypatch.setattr(
+        "app.api.v1.endpoints.auth.AuthService", FailingAuthService
+    )
+
+    from app.api.v1.endpoints.auth import authorize
+
+    request = AuthorizationRequest(
+        provider="local",
+        client_id="client",
+        redirect_uri="https://client.example.com/callback",
+        state="state-123",
+    )
+
+    with pytest.raises(HTTPException) as exc:
+        await authorize(request, AsyncMock())
+
+    assert exc.value.status_code == 400
+    assert "invalid payload" in exc.value.detail
+
+
+@pytest.mark.asyncio
+async def test_authorize_local_generic_error(monkeypatch) -> None:
+    """Unexpected errors should surface as HTTP 500 responses."""
+
+    class FailingAuthService:
+        def __init__(self, *_args, **_kwargs) -> None:
+            pass
+
+        async def authorize_local(self, *_args, **_kwargs):
+            raise RuntimeError("boom")
+
+    monkeypatch.setattr(
+        "app.api.v1.endpoints.auth.AuthService", FailingAuthService
+    )
+
+    from app.api.v1.endpoints.auth import authorize
+
+    request = AuthorizationRequest(
+        provider="local",
+        client_id="client",
+        redirect_uri="https://client.example.com/callback",
+        state="state-123",
+        username="user@example.com",
+        password="secret",
+    )
+
+    with pytest.raises(HTTPException) as exc:
+        await authorize(request, AsyncMock())
+
+    assert exc.value.status_code == 500
+    assert "Authorization failed" in exc.value.detail
+
+
+@pytest.mark.asyncio
+async def test_token_external_missing_access_token(
+    monkeypatch, oauth_provider_stub, patch_oauth_provider_factory
+) -> None:
+    """Token endpoint should guard against providers omitting access tokens."""
+
+    oauth_provider_stub.tokens_response = {"refresh_token": "remote-refresh"}
+    patch_oauth_provider_factory(oauth_provider_stub)
+
+    monkeypatch.setattr(
+        "app.api.v1.endpoints.auth.AuthService", lambda *_args, **_kwargs: AsyncMock()
+    )
+
+    from app.api.v1.endpoints.auth import token
+
+    request = TokenRequest(
+        provider="google",
+        grant_type="authorization_code",
+        code="auth-code",
+        redirect_uri="https://client.example.com/callback",
+        client_id="client",
+    )
+
+    with pytest.raises(HTTPException) as exc:
+        await token(request, AsyncMock())
+
+    assert exc.value.status_code == 502
+    assert "did not return an access token" in exc.value.detail
+
+
+@pytest.mark.asyncio
+async def test_token_local_exchange_authentication_error(monkeypatch) -> None:
+    """Local token exchange failures should respond with HTTP 400."""
+
+    class DummyAuthService:
+        def __init__(self, *_args, **_kwargs) -> None:
+            pass
+
+        async def exchange_local_authorization_code(self, *_args, **_kwargs):
+            raise AuthenticationError("bad code")
+
+    monkeypatch.setattr(
+        "app.api.v1.endpoints.auth.AuthService", DummyAuthService
+    )
+
+    from app.api.v1.endpoints.auth import token
+
+    request = TokenRequest(
+        provider="local",
+        grant_type="authorization_code",
+        code="auth-code",
+        redirect_uri="https://client.example.com/callback",
+        client_id="client",
+    )
+
+    with pytest.raises(HTTPException) as exc:
+        await token(request, AsyncMock())
+
+    assert exc.value.status_code == 400
+    assert "bad code" in exc.value.detail
+
+
+@pytest.mark.asyncio
+async def test_token_external_invalid_id_token(
+    monkeypatch, oauth_provider_stub, patch_oauth_provider_factory
+) -> None:
+    """Invalid ID tokens from the provider should bubble up as HTTP 401."""
+
+    async def raise_invalid_id(*_args, **_kwargs):
+        raise AuthenticationError("bad id token")
+
+    oauth_provider_stub.tokens_response = {
+        "access_token": "remote-access",
+        "refresh_token": "remote-refresh",
+        "id_token": "bad-token",
+    }
+    oauth_provider_stub.user_info_response = {
+        "id": "user-id",
+        "email": "oauth@example.com",
+        "verified_email": True,
+        "name": "OAuth User",
+        "given_name": "OAuth",
+        "family_name": "User",
+        "picture": None,
+        "locale": "en-US",
+    }
+    oauth_provider_stub.validate_id_token = raise_invalid_id
+    patch_oauth_provider_factory(oauth_provider_stub)
+
+    async def fake_create_or_update(
+        self, google_user_info, refresh_token=None
+    ) -> tuple[SimpleNamespace, bool]:
+        user = SimpleNamespace(
+            id=42,
+            email=google_user_info.email,
+            username="oauth-user",
+            full_name=google_user_info.name,
+        )
+        return user, False
+
+    monkeypatch.setattr(
+        "app.api.v1.endpoints.auth.AuthService", lambda *_args, **_kwargs: AsyncMock()
+    )
+    monkeypatch.setattr(
+        "app.api.v1.endpoints.auth.UserService.create_or_update_oauth_user",
+        fake_create_or_update,
+    )
+
+    from app.api.v1.endpoints.auth import token
+
+    request = TokenRequest(
+        provider="google",
+        grant_type="authorization_code",
+        code="auth-code",
+        redirect_uri="https://client.example.com/callback",
+        client_id="client",
+    )
+
+    with pytest.raises(HTTPException) as exc:
+        await token(request, AsyncMock())
+
+    assert exc.value.status_code == 401
+    assert "Invalid ID token" in exc.value.detail
+
+
+@pytest.mark.asyncio
+async def test_token_external_user_info_failure(
+    monkeypatch, oauth_provider_stub, patch_oauth_provider_factory
+) -> None:
+    """Provider user info failures should map to HTTP 401."""
+
+    async def fail_user_info(*_args, **_kwargs):
+        raise AuthenticationError("no profile")
+
+    oauth_provider_stub.tokens_response = {"access_token": "token"}
+    oauth_provider_stub.get_user_info = fail_user_info
+    patch_oauth_provider_factory(oauth_provider_stub)
+
+    monkeypatch.setattr(
+        "app.api.v1.endpoints.auth.AuthService", lambda *_args, **_kwargs: AsyncMock()
+    )
+
+    from app.api.v1.endpoints.auth import token
+
+    request = TokenRequest(
+        provider="google",
+        grant_type="authorization_code",
+        code="auth-code",
+        redirect_uri="https://client.example.com/callback",
+        client_id="client",
+    )
+
+    with pytest.raises(HTTPException) as exc:
+        await token(request, AsyncMock())
+
+    assert exc.value.status_code == 401
+    assert "Failed to fetch user info" in exc.value.detail
+
+
+@pytest.mark.asyncio
+async def test_token_external_invalid_user_info(monkeypatch, oauth_provider_stub, patch_oauth_provider_factory) -> None:
+    """Malformed provider payloads should return HTTP 502."""
+
+    oauth_provider_stub.tokens_response = {"access_token": "token"}
+    oauth_provider_stub.user_info_response = {"id": "missing-email"}
+    patch_oauth_provider_factory(oauth_provider_stub)
+
+    monkeypatch.setattr(
+        "app.api.v1.endpoints.auth.AuthService", lambda *_args, **_kwargs: AsyncMock()
+    )
+
+    from app.api.v1.endpoints.auth import token
+
+    request = TokenRequest(
+        provider="google",
+        grant_type="authorization_code",
+        code="auth-code",
+        redirect_uri="https://client.example.com/callback",
+        client_id="client",
+    )
+
+    with pytest.raises(HTTPException) as exc:
+        await token(request, AsyncMock())
+
+    assert exc.value.status_code == 502
+    assert "Invalid user info from Google" in exc.value.detail
+
+
+@pytest.mark.asyncio
+async def test_token_external_provider_not_implemented(
+    monkeypatch, oauth_provider_stub, patch_oauth_provider_factory
+) -> None:
+    """Non-Google providers should return HTTP 501 until implemented."""
+
+    oauth_provider_stub.tokens_response = {"access_token": "token"}
+    oauth_provider_stub.user_info_response = {
+        "id": "provider-id",
+        "email": "user@example.com",
+        "verified_email": True,
+        "name": "Other Provider",
+        "given_name": "Other",
+        "family_name": "Provider",
+        "picture": None,
+        "locale": "en-US",
+    }
+    patch_oauth_provider_factory(oauth_provider_stub)
+
+    monkeypatch.setattr(
+        "app.api.v1.endpoints.auth.AuthService", lambda *_args, **_kwargs: AsyncMock()
+    )
+
+    from app.api.v1.endpoints.auth import token
+
+    request = TokenRequest(
+        provider="entra",
+        grant_type="authorization_code",
+        code="auth-code",
+        redirect_uri="https://client.example.com/callback",
+        client_id="client",
+    )
+
+    with pytest.raises(HTTPException) as exc:
+        await token(request, AsyncMock())
+
+    assert exc.value.status_code == 501
+    assert "not implemented" in exc.value.detail
+
+
+@pytest.mark.asyncio
+async def test_token_generic_error(monkeypatch) -> None:
+    """Unexpected exceptions should surface as HTTP 500 responses."""
+
+    def raise_runtime_error(*_args, **_kwargs):
+        raise RuntimeError("factory exploded")
+
+    monkeypatch.setattr(
+        "app.api.v1.endpoints.auth.AuthService", lambda *_args, **_kwargs: AsyncMock()
+    )
+    monkeypatch.setattr(
+        "app.api.v1.endpoints.auth.OAuthProviderFactory.create_provider",
+        classmethod(lambda cls, provider: raise_runtime_error()),
+    )
+
+    from app.api.v1.endpoints.auth import token
+
+    request = TokenRequest(
+        provider="google",
+        grant_type="authorization_code",
+        code="auth-code",
+        redirect_uri="https://client.example.com/callback",
+        client_id="client",
+    )
+
+    with pytest.raises(HTTPException) as exc:
+        await token(request, AsyncMock())
+
+    assert exc.value.status_code == 500
+    assert "Token exchange failed" in exc.value.detail
+
+
+@pytest.mark.asyncio
+async def test_oauth_callback_error(monkeypatch) -> None:
+    """Callback should return 400 when provider reports an error."""
+
+    from app.api.v1.endpoints.auth import oauth_callback
+
+    with pytest.raises(HTTPException) as exc:
+        await oauth_callback("google", "code", error="access_denied", db=AsyncMock())
+
+    assert exc.value.status_code == 400
+    assert "OAuth authorization failed" in exc.value.detail
+
+
+@pytest.mark.asyncio
+async def test_oauth_callback_success_includes_state(monkeypatch) -> None:
+    """Callback should redirect with provider, code, and state parameters."""
+
+    from app.api.v1.endpoints.auth import oauth_callback
+
+    response = await oauth_callback("google", "code-123", state="xyz", db=AsyncMock())
+
+    assert response.status_code in {302, 307}
+    assert "code=code-123" in str(response.headers["location"]).lower()
+    assert "state=xyz" in response.headers["location"]
+
+
+@pytest.mark.asyncio
+async def test_revoke_token_handles_invalid_token(monkeypatch) -> None:
+    """Revocation endpoint should swallow verification errors."""
+
+    def raise_error(_token: str) -> None:
+        raise ValueError("bad token")
+
+    monkeypatch.setattr("app.api.v1.endpoints.auth.verify_token", raise_error)
+
+    from app.api.v1.endpoints.auth import revoke_token
+
+    result = await revoke_token("not-a-token", AsyncMock())
+    assert result == {"message": "Token revoked successfully"}

--- a/tests/unit/test_auth_endpoint_errors.py
+++ b/tests/unit/test_auth_endpoint_errors.py
@@ -298,7 +298,9 @@ async def test_token_external_user_info_failure(
 
 
 @pytest.mark.asyncio
-async def test_token_external_invalid_user_info(monkeypatch, oauth_provider_stub, patch_oauth_provider_factory) -> None:
+async def test_token_external_invalid_user_info(
+    monkeypatch, oauth_provider_stub, patch_oauth_provider_factory
+) -> None:
     """Malformed provider payloads should return HTTP 502."""
 
     oauth_provider_stub.tokens_response = {"access_token": "token"}

--- a/tests/unit/test_database_helpers.py
+++ b/tests/unit/test_database_helpers.py
@@ -1,0 +1,397 @@
+"""Unit tests for the database helpers in app.core.database."""
+
+from __future__ import annotations
+
+from contextlib import asynccontextmanager
+from types import SimpleNamespace
+from typing import Any
+
+import pytest
+from sqlalchemy.exc import DisconnectionError
+
+from app.core import database
+
+
+class DummyResult:
+    """Simple result wrapper mirroring SQLAlchemy scalar behaviour."""
+
+    def __init__(self, value: Any):
+        self._value = value
+
+    def scalar(self) -> Any:
+        return self._value
+
+
+class DummySession:
+    """Lightweight async session double used across tests."""
+
+    def __init__(self, *, should_fail: bool = False, result_value: Any = None):
+        self.should_fail = should_fail
+        self.result_value = result_value
+        self.commit_called = False
+        self.rollback_called = False
+        self.close_called = False
+
+    async def execute(self, _query: Any) -> DummyResult:
+        if self.should_fail:
+            raise DisconnectionError("temporary connection drop")
+        return DummyResult(self.result_value)
+
+    async def commit(self) -> None:
+        self.commit_called = True
+
+    async def rollback(self) -> None:
+        self.rollback_called = True
+
+    async def close(self) -> None:
+        self.close_called = True
+
+
+@pytest.mark.asyncio
+async def test_get_async_db_retries_then_yields_session(monkeypatch):
+    """`get_async_db` should retry on disconnection and eventually yield a session."""
+
+    attempts: list[DummySession] = []
+
+    def fake_session_factory() -> DummySession:
+        session = DummySession(should_fail=len(attempts) == 0, result_value=1)
+        attempts.append(session)
+        return session
+
+    sleep_calls: list[float] = []
+
+    async def fake_sleep(delay: float) -> None:  # pragma: no cover - exercised indirectly
+        sleep_calls.append(delay)
+
+    monkeypatch.setattr(database, "AsyncSessionLocal", fake_session_factory)
+    monkeypatch.setattr(database.asyncio, "sleep", fake_sleep)
+
+    generator = database.get_async_db()
+
+    session = await generator.__anext__()
+    assert isinstance(session, DummySession)
+
+    with pytest.raises(StopAsyncIteration):
+        await generator.asend(None)
+
+    assert len(attempts) == 2
+    assert attempts[0].rollback_called is True
+    assert attempts[0].close_called is True
+    assert attempts[1].commit_called is True
+    assert attempts[1].close_called is True
+    # Exponential backoff should have been triggered once for the retry
+    assert sleep_calls == [2.0]
+
+
+@pytest.mark.asyncio
+async def test_get_async_db_raises_after_max_retries(monkeypatch):
+    """`get_async_db` should surface connection errors after exhausting retries."""
+
+    attempts: list[DummySession] = []
+
+    def failing_session_factory() -> DummySession:
+        session = DummySession(should_fail=True)
+        attempts.append(session)
+        return session
+
+    async def fake_sleep(_delay: float) -> None:
+        pass
+
+    monkeypatch.setattr(database, "AsyncSessionLocal", failing_session_factory)
+    monkeypatch.setattr(database.asyncio, "sleep", fake_sleep)
+
+    generator = database.get_async_db()
+    with pytest.raises(DisconnectionError):
+        await generator.__anext__()
+
+    # All sessions should have been closed after each failed attempt
+    assert len(attempts) == 3
+    assert all(session.close_called for session in attempts)
+    assert all(session.rollback_called for session in attempts)
+
+
+def test_get_engine_config_sqlite(monkeypatch, tmp_path):
+    """SQLite engines should include StaticPool and WAL pragmas."""
+
+    sqlite_db = tmp_path / "db.sqlite3"
+    settings_stub = SimpleNamespace(
+        DEBUG=False,
+        DATABASE_URL=f"sqlite:///{sqlite_db}",
+        DATABASE_URL_ASYNC=f"sqlite+aiosqlite:///{sqlite_db}",
+        DATABASE_TYPE="sqlite",
+        is_sqlite=True,
+        is_postgresql=False,
+    )
+    monkeypatch.setattr(database, "settings", settings_stub)
+
+    engine_kwargs, async_engine_kwargs = database.get_engine_config()
+
+    assert engine_kwargs["poolclass"].__name__ == "StaticPool"
+    assert engine_kwargs["connect_args"]["check_same_thread"] is False
+    assert "timeout" in engine_kwargs["connect_args"]
+    assert async_engine_kwargs["pool_pre_ping"] is True
+
+
+def test_get_engine_config_postgresql(monkeypatch):
+    """PostgreSQL engines should request queue pool parameters and async connect args."""
+
+    settings_stub = SimpleNamespace(
+        DEBUG=True,
+        DATABASE_URL="postgresql://example/db",
+        DATABASE_URL_ASYNC="postgresql+asyncpg://example/db",
+        DATABASE_TYPE="postgresql",
+        is_sqlite=False,
+        is_postgresql=True,
+    )
+    monkeypatch.setattr(database, "settings", settings_stub)
+
+    engine_kwargs, async_engine_kwargs = database.get_engine_config()
+
+    assert engine_kwargs["poolclass"].__name__ == "QueuePool"
+    assert engine_kwargs["pool_pre_ping"] is True
+    assert async_engine_kwargs["connect_args"]["server_settings"]["application_name"] == "fastapi_app"
+
+
+@pytest.mark.asyncio
+async def test_check_database_health_handles_errors(monkeypatch):
+    """`check_database_health` should capture exceptions as error metadata."""
+
+    @asynccontextmanager
+    async def failing_context():
+        raise RuntimeError("boom")
+        yield  # pragma: no cover
+
+    monkeypatch.setattr(database, "get_async_db_context", failing_context)
+    monkeypatch.setattr(
+        database,
+        "settings",
+        SimpleNamespace(DATABASE_TYPE="sqlite", is_postgresql=False),
+    )
+
+    health = await database.check_database_health()
+    assert health["connection_status"] == "error"
+    assert health["error"] == "boom"
+
+
+@pytest.mark.asyncio
+async def test_validate_connection_success(monkeypatch):
+    """`validate_connection` should return True when the test query succeeds."""
+
+    session = DummySession(result_value=1)
+
+    @asynccontextmanager
+    async def successful_context():
+        yield session
+
+    monkeypatch.setattr(database, "get_async_db_context", successful_context)
+
+    assert await database.validate_connection() is True
+    assert session.commit_called is False
+    assert session.close_called is False
+
+
+@pytest.mark.asyncio
+async def test_get_async_db_context_manages_session(monkeypatch):
+    """`get_async_db_context` should commit and close sessions on success."""
+
+    session = DummySession(result_value=1)
+
+    monkeypatch.setattr(database, "AsyncSessionLocal", lambda: session)
+
+    async with database.get_async_db_context() as yielded_session:
+        assert yielded_session is session
+
+    assert session.commit_called is True
+    assert session.close_called is True
+
+
+@pytest.mark.asyncio
+async def test_close_database_connections_disposes_engines(monkeypatch):
+    """`close_database_connections` should dispose both async and sync engines."""
+
+    class DummyAsyncEngine:
+        def __init__(self) -> None:
+            self.disposed = False
+
+        async def dispose(self) -> None:
+            self.disposed = True
+
+    class DummyEngine:
+        def __init__(self) -> None:
+            self.disposed = False
+
+        def dispose(self) -> None:
+            self.disposed = True
+
+    async_engine = DummyAsyncEngine()
+    engine = DummyEngine()
+
+    monkeypatch.setattr(database, "async_engine", async_engine)
+    monkeypatch.setattr(database, "engine", engine)
+
+    await database.close_database_connections()
+
+    assert async_engine.disposed is True
+    assert engine.disposed is True
+
+
+@pytest.mark.asyncio
+async def test_create_tables_sqlite(monkeypatch):
+    """`create_tables` should call metadata.create_all when using SQLite."""
+
+    create_calls: list[Any] = []
+
+    def fake_create_all(*_args, **_kwargs) -> None:
+        create_calls.append(True)
+
+    monkeypatch.setattr(database.Base.metadata, "create_all", fake_create_all)
+    monkeypatch.setattr(
+        database,
+        "settings",
+        SimpleNamespace(
+            is_sqlite=True,
+            is_postgresql=False,
+            DATABASE_TYPE="sqlite",
+            DATABASE_URL="sqlite:///./test.db",
+        ),
+    )
+
+    await database.create_tables()
+
+    assert create_calls
+
+
+@pytest.mark.asyncio
+async def test_create_tables_postgresql(monkeypatch):
+    """PostgreSQL table creation should run metadata via async engine."""
+
+    create_calls: list[Any] = []
+
+    def fake_create_all(_bind=None) -> None:
+        create_calls.append(True)
+
+    monkeypatch.setattr(database.Base.metadata, "create_all", fake_create_all)
+
+    class DummyConnection:
+        def __init__(self) -> None:
+            self.sync_called = False
+
+        async def __aenter__(self) -> DummyConnection:
+            return self
+
+        async def __aexit__(self, exc_type, exc, tb) -> bool:
+            return False
+
+        async def run_sync(self, func):
+            self.sync_called = True
+            func("connection")
+
+    class DummyAsyncEngine:
+        def __init__(self) -> None:
+            self.connection = DummyConnection()
+
+        @asynccontextmanager
+        async def begin(self):
+            yield self.connection
+
+    dummy_engine = DummyAsyncEngine()
+
+    monkeypatch.setattr(database, "async_engine", dummy_engine)
+    monkeypatch.setattr(
+        database,
+        "settings",
+        SimpleNamespace(
+            is_sqlite=False,
+            is_postgresql=True,
+            DATABASE_TYPE="postgresql",
+        ),
+    )
+
+    await database.create_tables()
+
+    assert dummy_engine.connection.sync_called is True
+    assert create_calls
+
+
+@pytest.mark.asyncio
+async def test_init_database_success(monkeypatch):
+    """`init_database` should create tables and seed default roles."""
+
+    health_calls: list[Any] = []
+    create_called: list[Any] = []
+    ensure_called: list[Any] = []
+
+    async def fake_check_health() -> dict[str, Any]:
+        health_calls.append(True)
+        return {"connection_status": "healthy"}
+
+    async def fake_create_tables() -> None:
+        create_called.append(True)
+
+    async def fake_ensure_default_roles(_session) -> None:
+        ensure_called.append(True)
+
+    class DummySession:
+        async def __aenter__(self) -> DummySession:
+            return self
+
+        async def __aexit__(self, exc_type, exc, tb) -> bool:
+            return False
+
+    monkeypatch.setattr(database, "check_database_health", fake_check_health)
+    monkeypatch.setattr(database, "create_tables", fake_create_tables)
+    monkeypatch.setattr(database, "ensure_default_roles", fake_ensure_default_roles)
+    monkeypatch.setattr(database, "AsyncSessionLocal", lambda: DummySession())
+    monkeypatch.setattr(
+        database,
+        "settings",
+        SimpleNamespace(
+            DATABASE_TYPE="sqlite",
+            is_sqlite=True,
+            DATABASE_URL="sqlite:///./test.db",
+        ),
+    )
+
+    await database.init_database()
+
+    assert health_calls
+    assert create_called
+    assert ensure_called
+
+
+@pytest.mark.asyncio
+async def test_init_database_health_failure(monkeypatch):
+    """`init_database` should raise when the health check fails."""
+
+    async def fake_check_health() -> dict[str, Any]:
+        return {"connection_status": "error"}
+
+    monkeypatch.setattr(database, "check_database_health", fake_check_health)
+    monkeypatch.setattr(database, "settings", SimpleNamespace(DATABASE_TYPE="sqlite", is_sqlite=True))
+
+    with pytest.raises(RuntimeError):
+        await database.init_database()
+
+
+@pytest.mark.asyncio
+async def test_check_database_health_success(monkeypatch):
+    """Healthy connections should include pool status metadata."""
+
+    session = DummySession(result_value=1)
+
+    @asynccontextmanager
+    async def successful_context():
+        yield session
+
+    monkeypatch.setattr(database, "get_async_db_context", successful_context)
+    monkeypatch.setattr(
+        database,
+        "settings",
+        SimpleNamespace(DATABASE_TYPE="postgresql", is_postgresql=True),
+    )
+    monkeypatch.setattr(database, "async_engine", SimpleNamespace(pool=object()))
+
+    health = await database.check_database_health()
+
+    assert health["connection_status"] == "healthy"
+    assert health["pool_status"]["pool_available"] is True

--- a/tests/unit/test_google_oauth_provider.py
+++ b/tests/unit/test_google_oauth_provider.py
@@ -1,0 +1,388 @@
+"""Unit tests for the Google OAuth provider and factory helpers."""
+
+from __future__ import annotations
+
+from typing import Any
+
+import httpx
+import pytest
+
+from app.core.exceptions import AuthenticationError, ValidationError
+from app.services.oauth.base import BaseOAuthProvider
+from app.services.oauth.factory import OAuthProviderFactory
+from app.services.oauth.google import GoogleOAuthProvider
+
+ORIGINAL_PROVIDERS = OAuthProviderFactory._providers.copy()
+
+
+class StubResponse:
+    """Minimal HTTPX response stub with configurable behaviour."""
+
+    def __init__(self, json_data: dict[str, Any] | None = None, *, text: str = "") -> None:
+        self._json = json_data or {}
+        self.text = text
+        self._raise_exc: httpx.HTTPStatusError | None = None
+
+    def set_http_error(self, status_code: int, method: str = "POST") -> None:
+        request = httpx.Request(method, "https://example.com")
+        response = httpx.Response(status_code, request=request, text=self.text)
+        self._raise_exc = httpx.HTTPStatusError(
+            self.text or "error", request=request, response=response
+        )
+
+    def raise_for_status(self) -> None:
+        if self._raise_exc:
+            raise self._raise_exc
+
+    def json(self) -> dict[str, Any]:
+        return self._json
+
+
+class AsyncClientStub:
+    """Context manager stub that returns preconfigured responses."""
+
+    def __init__(
+        self,
+        *,
+        post_response: StubResponse | None = None,
+        get_response: StubResponse | None = None,
+        post_exception: Exception | None = None,
+        get_exception: Exception | None = None,
+    ) -> None:
+        self.post_response = post_response
+        self.get_response = get_response
+        self.post_exception = post_exception
+        self.get_exception = get_exception
+        self.post_calls: list[tuple[str, dict[str, Any] | None]] = []
+        self.get_calls: list[tuple[str, dict[str, str] | None]] = []
+
+    async def __aenter__(self) -> AsyncClientStub:
+        return self
+
+    async def __aexit__(self, exc_type, exc, tb) -> bool:
+        return False
+
+    async def post(self, url: str, data: dict[str, Any] | None = None) -> StubResponse:
+        self.post_calls.append((url, data))
+        if self.post_exception:
+            raise self.post_exception
+        assert self.post_response is not None
+        return self.post_response
+
+    async def get(self, url: str, headers: dict[str, str] | None = None) -> StubResponse:
+        self.get_calls.append((url, headers))
+        if self.get_exception:
+            raise self.get_exception
+        assert self.get_response is not None
+        return self.get_response
+
+
+@pytest.fixture(autouse=True)
+def reset_oauth_factory(monkeypatch) -> None:
+    """Ensure each test operates on a clean provider registry."""
+
+    monkeypatch.setattr(
+        OAuthProviderFactory, "_providers", ORIGINAL_PROVIDERS.copy(), raising=False
+    )
+
+
+@pytest.mark.asyncio
+async def test_get_authorization_url_includes_pkce() -> None:
+    """Authorization URLs should include PKCE parameters when provided."""
+
+    provider = GoogleOAuthProvider()
+    url = await provider.get_authorization_url(
+        redirect_uri="https://client.example.com/callback",
+        state="state-123",
+        scope="openid email",
+        code_challenge="challenge-value",
+    )
+
+    assert "code_challenge=challenge-value" in url
+    assert "code_challenge_method=S256" in url
+    assert "state=state-123" in url
+
+
+@pytest.mark.asyncio
+async def test_exchange_code_for_tokens_success(monkeypatch) -> None:
+    """Successful token exchange should return provider payload."""
+
+    provider = GoogleOAuthProvider()
+    response = StubResponse({"access_token": "abc", "refresh_token": "def"})
+    client_stub = AsyncClientStub(post_response=response)
+    monkeypatch.setattr(
+        "app.services.oauth.google.httpx.AsyncClient",
+        lambda *args, **kwargs: client_stub,
+    )
+
+    tokens = await provider.exchange_code_for_tokens(
+        "auth-code", "https://client.example.com/callback"
+    )
+
+    assert tokens["access_token"] == "abc"
+    assert client_stub.post_calls[0][0] == provider.token_uri
+
+
+@pytest.mark.asyncio
+async def test_exchange_code_for_tokens_http_error(monkeypatch) -> None:
+    """HTTP errors should be wrapped as AuthenticationError."""
+
+    provider = GoogleOAuthProvider()
+    response = StubResponse(text="invalid grant")
+    response.set_http_error(400)
+    client_stub = AsyncClientStub(post_response=response)
+    monkeypatch.setattr(
+        "app.services.oauth.google.httpx.AsyncClient",
+        lambda *args, **kwargs: client_stub,
+    )
+
+    with pytest.raises(AuthenticationError) as exc:
+        await provider.exchange_code_for_tokens(
+            "bad-code", "https://client.example.com/callback"
+        )
+    assert "Token exchange failed" in str(exc.value)
+
+
+@pytest.mark.asyncio
+async def test_exchange_code_for_tokens_generic_error(monkeypatch) -> None:
+    """Unexpected errors from httpx should also map to AuthenticationError."""
+
+    provider = GoogleOAuthProvider()
+    client_stub = AsyncClientStub(post_exception=RuntimeError("boom"))
+    monkeypatch.setattr(
+        "app.services.oauth.google.httpx.AsyncClient",
+        lambda *args, **kwargs: client_stub,
+    )
+
+    with pytest.raises(AuthenticationError) as exc:
+        await provider.exchange_code_for_tokens(
+            "code", "https://client.example.com/callback"
+        )
+    assert "Token exchange error" in str(exc.value)
+
+
+@pytest.mark.asyncio
+async def test_get_user_info_success(monkeypatch) -> None:
+    """User info requests should return JSON payloads from Google."""
+
+    provider = GoogleOAuthProvider()
+    response = StubResponse({"email": "user@example.com"})
+    client_stub = AsyncClientStub(get_response=response)
+    monkeypatch.setattr(
+        "app.services.oauth.google.httpx.AsyncClient",
+        lambda *args, **kwargs: client_stub,
+    )
+
+    data = await provider.get_user_info("access-token")
+
+    assert data["email"] == "user@example.com"
+    assert client_stub.get_calls[0][0] == provider.userinfo_uri
+    headers = client_stub.get_calls[0][1]
+    assert headers is not None
+    assert headers["Authorization"].startswith("Bearer ")
+
+
+@pytest.mark.asyncio
+async def test_get_user_info_http_error(monkeypatch) -> None:
+    """HTTP failures during user info retrieval should raise AuthenticationError."""
+
+    provider = GoogleOAuthProvider()
+    response = StubResponse(text="not authorised")
+    response.set_http_error(401, method="GET")
+    client_stub = AsyncClientStub(get_response=response)
+    monkeypatch.setattr(
+        "app.services.oauth.google.httpx.AsyncClient",
+        lambda *args, **kwargs: client_stub,
+    )
+
+    with pytest.raises(AuthenticationError) as exc:
+        await provider.get_user_info("bad-token")
+    assert "Failed to get user info" in str(exc.value)
+
+
+@pytest.mark.asyncio
+async def test_get_user_info_generic_error(monkeypatch) -> None:
+    """Unexpected user info errors should also map to AuthenticationError."""
+
+    provider = GoogleOAuthProvider()
+    client_stub = AsyncClientStub(get_exception=RuntimeError("boom"))
+    monkeypatch.setattr(
+        "app.services.oauth.google.httpx.AsyncClient",
+        lambda *args, **kwargs: client_stub,
+    )
+
+    with pytest.raises(AuthenticationError) as exc:
+        await provider.get_user_info("token")
+    assert "User info error" in str(exc.value)
+
+
+@pytest.mark.asyncio
+async def test_refresh_access_token_success(monkeypatch) -> None:
+    """Refresh token requests should proxy Google's response."""
+
+    provider = GoogleOAuthProvider()
+    response = StubResponse({"access_token": "new-token"})
+    client_stub = AsyncClientStub(post_response=response)
+    monkeypatch.setattr(
+        "app.services.oauth.google.httpx.AsyncClient",
+        lambda *args, **kwargs: client_stub,
+    )
+
+    refreshed = await provider.refresh_access_token("refresh-token")
+
+    assert refreshed["access_token"] == "new-token"
+    assert client_stub.post_calls[0][0] == provider.token_uri
+
+
+@pytest.mark.asyncio
+async def test_refresh_access_token_http_error(monkeypatch) -> None:
+    """Errors during refresh should bubble up as AuthenticationError."""
+
+    provider = GoogleOAuthProvider()
+    response = StubResponse(text="expired refresh")
+    response.set_http_error(400)
+    client_stub = AsyncClientStub(post_response=response)
+    monkeypatch.setattr(
+        "app.services.oauth.google.httpx.AsyncClient",
+        lambda *args, **kwargs: client_stub,
+    )
+
+    with pytest.raises(AuthenticationError) as exc:
+        await provider.refresh_access_token("stale-token")
+    assert "Token refresh failed" in str(exc.value)
+
+
+@pytest.mark.asyncio
+async def test_refresh_access_token_generic_error(monkeypatch) -> None:
+    """Unexpected refresh errors should raise AuthenticationError."""
+
+    provider = GoogleOAuthProvider()
+    client_stub = AsyncClientStub(post_exception=RuntimeError("boom"))
+    monkeypatch.setattr(
+        "app.services.oauth.google.httpx.AsyncClient",
+        lambda *args, **kwargs: client_stub,
+    )
+
+    with pytest.raises(AuthenticationError) as exc:
+        await provider.refresh_access_token("token")
+    assert "Token refresh error" in str(exc.value)
+
+
+@pytest.mark.asyncio
+async def test_validate_id_token_success(monkeypatch) -> None:
+    """ID token validation should return Google's decoded payload."""
+
+    provider = GoogleOAuthProvider()
+
+    class DummyLoop:
+        async def run_in_executor(self, _executor, func, *args, **kwargs):
+            return func()
+
+    monkeypatch.setattr(
+        "app.services.oauth.google.asyncio.get_event_loop",
+        lambda: DummyLoop(),
+    )
+    monkeypatch.setattr(
+        "app.services.oauth.google.id_token.verify_oauth2_token",
+        lambda token, request, client_id: {"sub": "123"},
+    )
+
+    payload = await provider.validate_id_token("token-value")
+    assert payload["sub"] == "123"
+
+
+@pytest.mark.asyncio
+async def test_validate_id_token_invalid(monkeypatch) -> None:
+    """Value errors from Google's verifier should surface as AuthenticationError."""
+
+    provider = GoogleOAuthProvider()
+
+    class DummyLoop:
+        async def run_in_executor(self, _executor, func, *args, **kwargs):
+            return func()
+
+    monkeypatch.setattr(
+        "app.services.oauth.google.asyncio.get_event_loop",
+        lambda: DummyLoop(),
+    )
+
+    def raise_value_error(*_args, **_kwargs):
+        raise ValueError("bad token")
+
+    monkeypatch.setattr(
+        "app.services.oauth.google.id_token.verify_oauth2_token",
+        raise_value_error,
+    )
+
+    with pytest.raises(AuthenticationError) as exc:
+        await provider.validate_id_token("token-value")
+    assert "Invalid ID token" in str(exc.value)
+
+
+@pytest.mark.asyncio
+async def test_validate_id_token_other_error(monkeypatch) -> None:
+    """Unexpected validation errors should also map to AuthenticationError."""
+
+    provider = GoogleOAuthProvider()
+
+    class DummyLoop:
+        async def run_in_executor(self, _executor, func, *args, **kwargs):
+            return func()
+
+    monkeypatch.setattr(
+        "app.services.oauth.google.asyncio.get_event_loop",
+        lambda: DummyLoop(),
+    )
+
+    def raise_runtime_error(*_args, **_kwargs):
+        raise RuntimeError("oops")
+
+    monkeypatch.setattr(
+        "app.services.oauth.google.id_token.verify_oauth2_token",
+        raise_runtime_error,
+    )
+
+    with pytest.raises(AuthenticationError) as exc:
+        await provider.validate_id_token("token-value")
+    assert "ID token validation error" in str(exc.value)
+
+
+def test_factory_unknown_provider_raises() -> None:
+    """Unsupported providers should raise ValidationError."""
+
+    with pytest.raises(ValidationError):
+        OAuthProviderFactory.create_provider("unknown")
+
+
+def test_factory_register_provider_creates_instance() -> None:
+    """Registering a custom provider should allow instantiation via the factory."""
+
+    class DummyProvider(BaseOAuthProvider):
+        async def get_authorization_url(
+            self,
+            redirect_uri: str,
+            state: str,
+            scope: str | None = None,
+            code_challenge: str | None = None,
+        ) -> str:
+            return f"{redirect_uri}?state={state}"
+
+        async def exchange_code_for_tokens(
+            self, code: str, redirect_uri: str, code_verifier: str | None = None
+        ) -> dict[str, Any]:
+            return {"code": code, "redirect_uri": redirect_uri}
+
+        async def validate_id_token(self, id_token: str) -> dict[str, Any]:
+            return {"token": id_token}
+
+        async def get_user_info(self, access_token: str) -> dict[str, Any]:
+            return {"token": access_token}
+
+        async def refresh_access_token(self, refresh_token: str) -> dict[str, Any]:
+            return {"token": refresh_token}
+
+    OAuthProviderFactory.register_provider("dummy", DummyProvider)
+    provider = OAuthProviderFactory.create_provider("dummy")
+
+    assert isinstance(provider, DummyProvider)
+    assert "dummy" in OAuthProviderFactory.get_supported_providers()


### PR DESCRIPTION
## Summary
- add FastAPI auth endpoint regression tests for credential edge cases, OAuth provider failures, and callback/revocation paths
- cover database helpers with retry, engine configuration, and initialization tests to exercise connection management logic
- extend Google OAuth provider unit tests and refresh documentation with the new 82% coverage baseline

## Testing
- uv run pytest --cov=app

------
https://chatgpt.com/codex/tasks/task_b_68e6742114f88332ac625d68e4aac4a0